### PR TITLE
file not found for solar screen more verbose

### DIFF
--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -1,4 +1,3 @@
-
 """Functions to interface with SunSaver
 
 """
@@ -27,7 +26,7 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 
 
 def get_solardisplay_info():
-    """Reads the solar data and formats it for display"""
+    """Read the solar data from CSV file and format it for display"""
     if not os.path.exists('/home/pi/dencam/solar.csv'):
         error_msg = "\nSolar information\nnot found\n\nPress " + \
                     "second\nbutton and \nrefer to \nset-up" + \
@@ -56,13 +55,12 @@ def get_solardisplay_info():
 
 
 def float_to_string(value):
-    """Turns numerical input to string to be able to display"""
+    """Turn numerical input to string for display"""
     return f"{value:.1f}"
 
 
 def log_solar_info():
-    """Reads solar data from the charge controller and writes
-it to a csv"""
+    """Read solar data from the SunSaver and write it to a CSV file"""
     usb_error = False
     solar_list = ['init']
     now = datetime.now()

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -1,5 +1,5 @@
-'''Handles the data import from the sunsaver mppt controller
-and formats the data to be displayed on the screen'''
+"""Functions to grab the data from the sunsaver mppt controller
+and format it to be displayed on the screen"""
 import csv
 import os
 from datetime import datetime
@@ -25,7 +25,7 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 
 
 def get_solardisplay_info():
-    '''Reads the solar data and formats it for display'''
+    """Reads the solar data and formats it for display"""
     if not os.path.exists('/home/pi/dencam/solar.csv'):
         error_msg = "\nSolar information\nnot found\n\nPress second \
 \nbutton and \nrefer to \nset-up instructions"
@@ -53,13 +53,13 @@ controller to Pi\n and press second\nbutton"
 
 
 def float_to_string(value):
-    '''Turns numerical input to string to be able to display'''
+    """Turns numerical input to string to be able to display"""
     return "{:.1f}".format(value)
 
 
 def log_solar_info():
-    '''Reads solar data from the charge controller and writes
-it to a csv'''
+    """Reads solar data from the charge controller and writes
+it to a csv"""
     usb_error = False
     solar_list = ['init']
     now = datetime.now()

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -1,4 +1,6 @@
+
 """Functions to interface with SunSaver
+
 """
 import csv
 import os
@@ -55,7 +57,7 @@ def get_solardisplay_info():
 
 def float_to_string(value):
     """Turns numerical input to string to be able to display"""
-    return "{:.1f}".format(value)
+    return f"{value:.1f}"
 
 
 def log_solar_info():

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -27,8 +27,8 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 def get_solardisplay_info():
     '''Reads the solar data and formats it for display'''
     if not os.path.exists('/home/pi/dencam/solar.csv'):
-        error_msg = "\nSolar information\nnot found\n\nEnsure \
-sunsaver_log.py\nis running as cronjob"
+        error_msg = "\nSolar information\nnot found\n\nPress circle \
+\nbutton and \nrefer to \nset-up instructions"
         return error_msg
     with open('/home/pi/dencam/solar.csv', newline='',
               encoding='utf8') as solar:
@@ -45,8 +45,12 @@ sunsaver_log.py\nis running as cronjob"
     solar_text += '\nAh Charge: ' + last_row['Ah_Charge']
     solar_text += '\nAh Load: ' + last_row['Ah_Load']
     solar_text += '\nAlarm: ' + last_row['Alarm']
-    solar_text += '\nMPPT_Error: ' + last_row['MPPT_Error']
-    return solar_text
+    usb_error =  last_row['MPPT_Error']
+    if usb_error == "USB PORT ERROR":
+        solar_text = "\nUSB Port Error"
+        return solar_text
+    else:
+        return solar_text
 
 
 def float_to_string(value):

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -45,12 +45,10 @@ def get_solardisplay_info():
     solar_text += '\nAh Charge: ' + last_row['Ah_Charge']
     solar_text += '\nAh Load: ' + last_row['Ah_Load']
     solar_text += '\nAlarm: ' + last_row['Alarm']
-    usb_error =  last_row['MPPT_Error']
+    usb_error = last_row['MPPT_Error']
     if usb_error == "USB PORT ERROR":
         solar_text = "\nUSB Port Error"
-        return solar_text
-    else:
-        return solar_text
+    return solar_text
 
 
 def float_to_string(value):

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -27,7 +27,7 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 def get_solardisplay_info():
     '''Reads the solar data and formats it for display'''
     if not os.path.exists('/home/pi/dencam/solar.csv'):
-        error_msg = "\nSolar information\nnot found\n\nPress circle \
+        error_msg = "\nSolar information\nnot found\n\nPress second \
 \nbutton and \nrefer to \nset-up instructions"
         return error_msg
     with open('/home/pi/dencam/solar.csv', newline='',

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -24,7 +24,9 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 
 def get_solardisplay_info():
     if not os.path.exists('/home/pi/dencam/solar.csv'):
-        return 'File Does Not Exist'
+        error_msg = "\nSolar information\nnot found\n\nEnsure \
+sunsaver_log.py\nis running as cronjob"
+        return error_msg
     with open('/home/pi/dencam/solar.csv', newline='', encoding='utf8') as cf:
         parsed_csvfile = cf.read()
         parsed_csvfile = parsed_csvfile.replace('\x00', '')

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -1,5 +1,5 @@
-"""Functions to grab the data from the sunsaver mppt controller
-and format it to be displayed on the screen"""
+"""Functions to interface with SunSaver
+"""
 import csv
 import os
 from datetime import datetime
@@ -27,8 +27,9 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 def get_solardisplay_info():
     """Reads the solar data and formats it for display"""
     if not os.path.exists('/home/pi/dencam/solar.csv'):
-        error_msg = "\nSolar information\nnot found\n\nPress second \
-\nbutton and \nrefer to \nset-up instructions"
+        error_msg = "\nSolar information\nnot found\n\nPress " + \
+                    "second\nbutton and \nrefer to \nset-up" + \
+                    " instructions"
         return error_msg
     with open('/home/pi/dencam/solar.csv', newline='',
               encoding='utf8') as solar:
@@ -47,8 +48,8 @@ def get_solardisplay_info():
     solar_text += '\nAlarm: ' + last_row['Alarm']
     usb_error = last_row['MPPT_Error']
     if usb_error == "USB PORT ERROR":
-        solar_text = "\nCheck USB connection\nfrom solar charge\n\
-controller to Pi\n and press second\nbutton"
+        solar_text = "\nCheck USB connection\nfrom solar charge\n" + \
+                     "controller to Pi\n and press second\nbutton"
     return solar_text
 
 

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -47,7 +47,8 @@ def get_solardisplay_info():
     solar_text += '\nAlarm: ' + last_row['Alarm']
     usb_error = last_row['MPPT_Error']
     if usb_error == "USB PORT ERROR":
-        solar_text = "\nUSB Port Error"
+        solar_text = "\nCheck USB connection\nfrom solar charge\n\
+controller to Pi\n and press second\nbutton"
     return solar_text
 
 


### PR DESCRIPTION
The solar screen displayed "file not found" when the solar log was not available to the script. this means that the sunsaver_log.py script hadn't been run, which needs to happen as a cronjob as per the readme. it does not mean that solar is not connected to the pi, just that there is no solar log file available. the solar might be plugged in, just not writing to that log file yet. the solution to this screen is to run sunsaver_log.py, and then if the solar is truly not connected then there will be a different error that shows after that- indicated by all the fields in the log file being marked as "NA"