### PR TITLE
add version of software to networking page

### DIFF
--- a/dencam.py
+++ b/dencam.py
@@ -19,12 +19,11 @@ import time
 import yaml
 from picamera.exc import PiCameraMMALError
 
-from dencam import logs
+from dencam import logs, __version__
 from dencam.buttons import ButtonHandler
 from dencam.recorder import Recorder
 from dencam.gui import ErrorScreen, Controller, State
 from dencam.networking import AirplaneMode
-
 
 parser = argparse.ArgumentParser()
 parser.add_argument('config_file',
@@ -33,7 +32,7 @@ args = parser.parse_args()
 
 LOGGING_LEVEL = logging.INFO
 log = logs.setup_logger(LOGGING_LEVEL)
-log.info('*** MINIDENCAM STARTING UP ***')
+log.info('*** MINIDENCAM v%s STARTING UP ***', __version__)
 strg = logging.getLevelName(log.getEffectiveLevel())
 # clearly below line only reports for debug and info levels
 log.info('Logging level is {}'.format(strg))

--- a/dencam/gui.py
+++ b/dencam/gui.py
@@ -287,11 +287,11 @@ class NetworkPage(tk.Frame):
                                  bg='black')
         self.ip_label.pack(fill=tk.X)
         self.version_label = tk.Label(self,
-                                      text=("Version: " + __version__),
+                                      text=("Firmware Version: " + __version__),
                                       font=fonts['smaller'],
                                       fg='red',
                                       bg='black')
-        self.version_label.pack(fill=tk.X)
+        self.version_label.pack(side=tk.BOTTOM, fill=tk.X)
 
 class BlankPage(tk.Frame):
     def __init__(self, parent, controller):

--- a/dencam/gui.py
+++ b/dencam/gui.py
@@ -287,7 +287,7 @@ class NetworkPage(tk.Frame):
                                  bg='black')
         self.ip_label.pack(fill=tk.X)
         self.version_label = tk.Label(self,
-                                      text=("Firmware Version: " + __version__),
+                                      text=("Firmware Version: "+ __version__),
                                       font=fonts['smaller'],
                                       fg='red',
                                       bg='black')

--- a/dencam/gui.py
+++ b/dencam/gui.py
@@ -287,11 +287,12 @@ class NetworkPage(tk.Frame):
                                  bg='black')
         self.ip_label.pack(fill=tk.X)
         self.version_label = tk.Label(self,
-                                      text=("Firmware Version: "+ __version__),
+                                      text=("DenCam Firmware v" + __version__),
                                       font=fonts['smaller'],
                                       fg='red',
                                       bg='black')
         self.version_label.pack(side=tk.BOTTOM, fill=tk.X)
+
 
 class BlankPage(tk.Frame):
     def __init__(self, parent, controller):

--- a/dencam/gui.py
+++ b/dencam/gui.py
@@ -11,6 +11,7 @@ import tkinter as tk
 import tkinter.font as tkFont
 from threading import Thread
 
+from dencam import __version__
 from dencam import networking
 from dencam import mppt
 
@@ -285,7 +286,12 @@ class NetworkPage(tk.Frame):
                                  fg='red',
                                  bg='black')
         self.ip_label.pack(fill=tk.X)
-
+        self.version_label = tk.Label(self,
+                                      text=("Version: " + __version__),
+                                      font=fonts['smaller'],
+                                      fg='red',
+                                      bg='black')
+        self.version_label.pack(fill=tk.X)
 
 class BlankPage(tk.Frame):
     def __init__(self, parent, controller):

--- a/dencam/logs.py
+++ b/dencam/logs.py
@@ -4,6 +4,7 @@ import getpass
 
 from datetime import datetime
 
+from dencam import __version__
 
 def setup_logger(level, filename=None):
     logger = logging.getLogger()
@@ -33,5 +34,6 @@ def setup_logger(level, filename=None):
     f_handler.setFormatter(f_formatter)
     logger.addHandler(f_handler)
     f_handler.setLevel(logging.DEBUG)
+    logger.info("Firmware Version:" +__version__)
 
     return logger

--- a/dencam/logs.py
+++ b/dencam/logs.py
@@ -4,7 +4,6 @@ import getpass
 
 from datetime import datetime
 
-from dencam import __version__
 
 def setup_logger(level, filename=None):
     logger = logging.getLogger()
@@ -34,6 +33,5 @@ def setup_logger(level, filename=None):
     f_handler.setFormatter(f_formatter)
     logger.addHandler(f_handler)
     f_handler.setLevel(logging.DEBUG)
-    logger.info("Firmware Version:" +__version__)
 
     return logger


### PR DESCRIPTION
displays the current version of the system on the networking page, the first page you see when you begin dencam. pulls from __init__