### PR TITLE
Refactor: Make `recorder.BaseRecorder` agnostic to camera type

### DIFF
--- a/dencam.py
+++ b/dencam.py
@@ -21,7 +21,7 @@ from picamera.exc import PiCameraMMALError
 
 from dencam import logs, __version__
 from dencam.buttons import ButtonHandler
-from dencam.recorder import Recorder
+from dencam.recorder_picamera import PicameraRecorder
 from dencam.gui import ErrorScreen, Controller, State
 from dencam.networking import AirplaneMode
 
@@ -55,7 +55,7 @@ def main():
         error_screen = None
         while checking_camera:
             try:
-                recorder = Recorder(configs)
+                recorder = PicameraRecorder(configs)
                 checking_camera = False
             except PiCameraMMALError as cam_error:
                 log.warning(cam_error)

--- a/dencam/recorder.py
+++ b/dencam/recorder.py
@@ -4,17 +4,12 @@ This module contains code associated with controlling the recording of
 video captured from the picamera.
 
 """
-
 import logging
 import os
 import getpass
 import time
 from datetime import datetime
 from abc import ABC, abstractmethod
-
-import picamera
-from picamera import PiCamera
-
 
 log = logging.getLogger(__name__)
 
@@ -42,15 +37,8 @@ class BaseRecorder(ABC):
 
         self.record_start_time = time.time()  # also used in initial countdown
 
-        # camera setup
-        log.info('Set up recording configurations')
-        self.camera = PiCamera(framerate=configs['FRAME_RATE'])
-        self.camera.rotation = configs['CAMERA_ROTATION']
-        self.camera.resolution = configs['CAMERA_RESOLUTION']
-        text_size = int((1/20) * configs['CAMERA_RESOLUTION'][1])
-        self.camera.annotate_text_size = text_size
-        self.camera.annotate_foreground = picamera.color.Color('white')
-        self.camera.annotate_background = picamera.color.Color('black')
+        # self.camera should be initialized in derived classes
+        self.camera = None
 
         # storage setup
         self.reserved_storage = (configs['PI_RESERVED_STORAGE']
@@ -59,6 +47,17 @@ class BaseRecorder(ABC):
         self.vid_file_size = file_size * configs['FILE_SIZE_SAFETY_FACTOR']
         self.last_known_video_path = None
         self.video_path = self._video_path_selector()
+
+    def finish_setup(self):
+        """Complete set up in derived class constructurs
+
+        Used in derived classes to do steps required to set up camera
+        configuration that must occur after the camera object is
+        initialized.
+
+        """
+        self.camera.rotation = self.configs['CAMERA_ROTATION']
+        self.camera.resolution = self.configs['CAMERA_RESOLUTION']
 
     @abstractmethod
     def stop_recording(self):

--- a/dencam/recorder_picamera.py
+++ b/dencam/recorder_picamera.py
@@ -1,0 +1,28 @@
+"""Picamera-based recorder classes
+
+"""
+import logging
+import picamera
+from picamera import PiCamera
+
+from dencam.recorder import Recorder
+
+log = logging.getLogger(__name__)
+
+
+class PicameraRecorder(Recorder):
+    """Recorder that uses a picamera
+
+    """
+    def __init__(self, configs):
+        super().__init__(configs)
+
+        # camera setup
+        log.info('Set up camera per configurations')
+        self.camera = PiCamera(framerate=configs['FRAME_RATE'])
+        text_size = int((1/20) * configs['CAMERA_RESOLUTION'][1])
+        self.camera.annotate_text_size = text_size
+        self.camera.annotate_foreground = picamera.color.Color('white')
+        self.camera.annotate_background = picamera.color.Color('black')
+
+        super().finish_setup()


### PR DESCRIPTION
Move picamera-specific bits out of `BaseRecorder`
    
In prep for adding code to handle a different kind of camera (i.e. a ptz network surveillance camera for cyclops project), refactoring out picamera-specific bits of `BaseRecorder` and into a derived class (via the subclass `Recorder` as that's got some stuff we want, too).  The derived class is in a separate module so that the picamera package import is only required in that module.  The idea is that we will make a similar derived class for the ptz camera, and `BaseRecorder` and `Recorder` (and thus ideally everything in `recorder.py`) will be truly agnostic to the difference systems.
    
An assumption is that we will wrap the ptz camera control code in methods that match those of `picamera.PiCamera` so that every place in `recorder.py` that `self.camera` uses those methods it will all work.
    
Ideally, we will also be able to do a similar thing with changes necessary for picamera2 i.e. make class derived from `Recorder` in its own module that implements everything as it needs to be for using picamera2.  That is part of the reason we didn't use an alternate solution: making a camera object an argument to `BaseRecorder` constructor and initializing the camera in the top-level application module.

Resolves #98 
