### PR TITLE
80 solar label hardcoded

### DIFF
--- a/dencam/example_config.yaml
+++ b/dencam/example_config.yaml
@@ -1,8 +1,8 @@
 # length of videos to record in seconds
 RECORD_LENGTH: 300  # 60 * 5 = 300 for 5 minutes
 
-# file path to dencam (default hostname is pi)
-DENCAM_PATH: /home/pi/dencam/
+# directory for solar log (default hostname is pi)
+SOLAR_DIR: /home/USER/
 
 FILE_SIZE_SAFETY_FACTOR: 2  # between 2 and 10
 PI_RESERVED_STORAGE: 2000  # in megabytes

--- a/dencam/example_config.yaml
+++ b/dencam/example_config.yaml
@@ -1,6 +1,9 @@
 # length of videos to record in seconds
 RECORD_LENGTH: 300  # 60 * 5 = 300 for 5 minutes
 
+# file path to dencam (default hostname is pi)
+DENCAM_PATH: /home/pi/dencam/
+
 FILE_SIZE_SAFETY_FACTOR: 2  # between 2 and 10
 PI_RESERVED_STORAGE: 2000  # in megabytes
 AVG_VIDEO_FILE_SIZE: 1500  # in megabytes (1 gigabyte = 1000 megabytes)

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -8,6 +8,7 @@ from io import StringIO
 
 import minimalmodbus
 from serial import SerialException
+import yaml
 
 
 alarm_list = ["RTS open", "RTS shorted", "RTS disconnected",
@@ -27,12 +28,15 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 
 def get_solardisplay_info():
     """Read the solar data from CSV file and format it for display"""
-    if not os.path.exists('/home/pi/dencam/solar.csv'):
+    with open(./solar_path.yaml) as f:
+        path = yaml.load(f, Loader=yaml.SafeLoader)
+    solar_path = path['PATH']
+    if not os.path.exists(solar_path):
         error_msg = "\nSolar information\nnot found\n\nPress " + \
                     "second\nbutton and \nrefer to \nset-up" + \
                     " instructions"
         return error_msg
-    with open('/home/pi/dencam/solar.csv', newline='',
+    with open(solar_path, newline='',
               encoding='utf8') as solar:
         parsed_csvfile = solar.read()
         parsed_csvfile = parsed_csvfile.replace('\x00', '')
@@ -113,12 +117,16 @@ def log_solar_info():
                           'NO CONNECTION TO  SUNSAVER']
         sunsaver.serial.close()
 
-    if not os.path.exists('/home/pi/dencam/solar.csv'):
-        with open('/home/pi/dencam/solar.csv', 'w', newline='',
+    with open(./solar_path.yaml) as f:
+        path = yaml.load(f, Loader=yaml.SafeLoader)
+    solar_path = path['PATH']
+
+    if not os.path.exists(solar_path):
+        with open(solar_path, 'w', newline='',
                   encoding='utf8') as csvfile:
             csvwriter = csv.DictWriter(csvfile, fieldnames=field_names)
             csvwriter.writeheader()
-    with open('/home/pi/dencam/solar.csv', 'a', newline='',
+    with open(solar_path, 'a', newline='',
               encoding='utf8') as csv_file:
         csvwriter = csv.DictWriter(csv_file, fieldnames=field_names)
         csvwriter.writerow({'Date': solar_list[0],

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -28,7 +28,7 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 
 def get_solardisplay_info():
     """Read the solar data from CSV file and format it for display"""
-    with open(./solar_path.yaml) as f:
+    with open(solar_path.yaml) as f:
         path = yaml.load(f, Loader=yaml.SafeLoader)
     solar_path = path['PATH']
     if not os.path.exists(solar_path):
@@ -117,7 +117,7 @@ def log_solar_info():
                           'NO CONNECTION TO  SUNSAVER']
         sunsaver.serial.close()
 
-    with open(./solar_path.yaml) as f:
+    with open(solar_path.yaml) as f:
         path = yaml.load(f, Loader=yaml.SafeLoader)
     solar_path = path['PATH']
 

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -113,7 +113,7 @@ def log_solar_info():
                           'NO CONNECTION TO  SUNSAVER']
         sunsaver.serial.close()
 
-    if not os.path.exists(solar_path):
+    if not os.path.exists("./solar.csv"):
         with open("./solar.csv", 'w', newline='',
                   encoding='utf8') as csvfile:
             csvwriter = csv.DictWriter(csvfile, fieldnames=field_names)

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -28,7 +28,7 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 
 def get_solardisplay_info():
     """Read the solar data from CSV file and format it for display"""
-    with open(solar_path.yaml) as f:
+    with open("dencam/solar_path.yaml") as f:
         path = yaml.load(f, Loader=yaml.SafeLoader)
     solar_path = path['PATH']
     if not os.path.exists(solar_path):
@@ -117,7 +117,7 @@ def log_solar_info():
                           'NO CONNECTION TO  SUNSAVER']
         sunsaver.serial.close()
 
-    with open(solar_path.yaml) as f:
+    with open("dencam/solar_path.yaml") as f:
         path = yaml.load(f, Loader=yaml.SafeLoader)
     solar_path = path['PATH']
 

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -5,6 +5,8 @@ import csv
 import os
 from datetime import datetime
 from io import StringIO
+import argparse
+import yaml
 
 import minimalmodbus
 from serial import SerialException
@@ -27,12 +29,13 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 
 def get_solardisplay_info():
     """Read the solar data from CSV file and format it for display"""
-    if not os.path.exists("./solar.csv"):
+    path = get_file_path()
+    if not os.path.exists(path + "solar.csv"):
         error_msg = "\nSolar information\nnot found\n\nPress " + \
                     "second\nbutton and \nrefer to \nset-up" + \
                     " instructions"
         return error_msg
-    with open("./solar.csv", newline='',
+    with open(path + "solar.csv", newline='',
               encoding='utf8') as solar:
         parsed_csvfile = solar.read()
         parsed_csvfile = parsed_csvfile.replace('\x00', '')
@@ -112,13 +115,13 @@ def log_solar_info():
                           'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
                           'NO CONNECTION TO  SUNSAVER']
         sunsaver.serial.close()
-
-    if not os.path.exists("./solar.csv"):
-        with open("./solar.csv", 'w', newline='',
+    path = get_file_path()
+    if not os.path.exists(path + "solar.csv"):
+        with open(path + "solar.csv", 'w', newline='',
                   encoding='utf8') as csvfile:
             csvwriter = csv.DictWriter(csvfile, fieldnames=field_names)
             csvwriter.writeheader()
-    with open("./solar.csv", 'a', newline='',
+    with open(path + "solar.csv", 'a', newline='',
               encoding='utf8') as csv_file:
         csvwriter = csv.DictWriter(csv_file, fieldnames=field_names)
         csvwriter.writerow({'Date': solar_list[0],
@@ -135,3 +138,19 @@ def log_solar_info():
                             'Ah_Load': solar_list[11],
                             'Alarm': solar_list[12],
                             'MPPT_Error': solar_list[13]})
+
+
+def get_file_path():
+    '''Function to read config file and obtain home directory
+    of Dencam codebase
+
+    Returns: string containing file path of home directory
+    '''
+    parser = argparse.ArgumentParser()
+    parser.add_argument('config_file',
+                        help='Filename of configuration file')
+    args = parser.parse_args()
+    with open(args.config_file, encoding='utf-8') as config:
+        configs = yaml.load(config, Loader=yaml.SafeLoader)
+    path_to_dencam = configs['DENCAM_PATH']
+    return path_to_dencam

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -30,12 +30,13 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 def get_solardisplay_info():
     """Read the solar data from CSV file and format it for display"""
     path = get_file_path()
-    if not os.path.exists(path + "solar.csv"):
+    solar_log = os.path.join(path, "solar.csv")
+    if not os.path.exists(solar_log):
         error_msg = "\nSolar information\nnot found\n\nPress " + \
                     "second\nbutton and \nrefer to \nset-up" + \
                     " instructions"
         return error_msg
-    with open(path + "solar.csv", newline='',
+    with open(solar_log, newline='',
               encoding='utf8') as solar:
         parsed_csvfile = solar.read()
         parsed_csvfile = parsed_csvfile.replace('\x00', '')
@@ -116,12 +117,13 @@ def log_solar_info():
                           'NO CONNECTION TO  SUNSAVER']
         sunsaver.serial.close()
     path = get_file_path()
-    if not os.path.exists(path + "solar.csv"):
-        with open(path + "solar.csv", 'w', newline='',
+    solar_log = os.path.join(path, "solar.csv")
+    if not os.path.exists(solar_log):
+        with open(solar_log, 'w', newline='',
                   encoding='utf8') as csvfile:
             csvwriter = csv.DictWriter(csvfile, fieldnames=field_names)
             csvwriter.writeheader()
-    with open(path + "solar.csv", 'a', newline='',
+    with open(solar_log, 'a', newline='',
               encoding='utf8') as csv_file:
         csvwriter = csv.DictWriter(csv_file, fieldnames=field_names)
         csvwriter.writerow({'Date': solar_list[0],
@@ -141,10 +143,10 @@ def log_solar_info():
 
 
 def get_file_path():
-    '''Function to read config file and obtain home directory
-    of Dencam codebase
+    '''Function to read config file and obtain directory
+    for solar log
 
-    Returns: string containing file path of home directory
+    Returns: string containing file path of solar directory
     '''
     parser = argparse.ArgumentParser()
     parser.add_argument('config_file',
@@ -152,5 +154,5 @@ def get_file_path():
     args = parser.parse_args()
     with open(args.config_file, encoding='utf-8') as config:
         configs = yaml.load(config, Loader=yaml.SafeLoader)
-    path_to_dencam = configs['DENCAM_PATH']
-    return path_to_dencam
+    path_to_dir = configs['SOLAR_DIR']
+    return path_to_dir

--- a/dencam/mppt.py
+++ b/dencam/mppt.py
@@ -8,7 +8,6 @@ from io import StringIO
 
 import minimalmodbus
 from serial import SerialException
-import yaml
 
 
 alarm_list = ["RTS open", "RTS shorted", "RTS disconnected",
@@ -28,15 +27,12 @@ field_names = ['Date', 'Time', 'Battery_Voltage', 'Array_Voltage',
 
 def get_solardisplay_info():
     """Read the solar data from CSV file and format it for display"""
-    with open("dencam/solar_path.yaml") as f:
-        path = yaml.load(f, Loader=yaml.SafeLoader)
-    solar_path = path['PATH']
-    if not os.path.exists(solar_path):
+    if not os.path.exists("./solar.csv"):
         error_msg = "\nSolar information\nnot found\n\nPress " + \
                     "second\nbutton and \nrefer to \nset-up" + \
                     " instructions"
         return error_msg
-    with open(solar_path, newline='',
+    with open("./solar.csv", newline='',
               encoding='utf8') as solar:
         parsed_csvfile = solar.read()
         parsed_csvfile = parsed_csvfile.replace('\x00', '')
@@ -117,16 +113,12 @@ def log_solar_info():
                           'NO CONNECTION TO  SUNSAVER']
         sunsaver.serial.close()
 
-    with open("dencam/solar_path.yaml") as f:
-        path = yaml.load(f, Loader=yaml.SafeLoader)
-    solar_path = path['PATH']
-
     if not os.path.exists(solar_path):
-        with open(solar_path, 'w', newline='',
+        with open("./solar.csv", 'w', newline='',
                   encoding='utf8') as csvfile:
             csvwriter = csv.DictWriter(csvfile, fieldnames=field_names)
             csvwriter.writeheader()
-    with open(solar_path, 'a', newline='',
+    with open("./solar.csv", 'a', newline='',
               encoding='utf8') as csv_file:
         csvwriter = csv.DictWriter(csv_file, fieldnames=field_names)
         csvwriter.writerow({'Date': solar_list[0],

--- a/dencam/solar_path.yaml
+++ b/dencam/solar_path.yaml
@@ -1,1 +1,1 @@
-PATH: ~/home/katie/dencam2/dencam/solar.csv
+PATH: "/home/katie/dencam2/dencam/solar.csv"

--- a/dencam/solar_path.yaml
+++ b/dencam/solar_path.yaml
@@ -1,0 +1,1 @@
+PATH: ~/home/katie/dencam2/dencam/solar.csv

--- a/dencam/solar_path.yaml
+++ b/dencam/solar_path.yaml
@@ -1,1 +1,0 @@
-PATH: "/home/katie/dencam2/dencam/solar.csv"


### PR DESCRIPTION
The "pi" user was hardcoded into the paths used by mppt.py to obtain and add new lines to solar.csv when both sunsaver_log.py gets called and also when it's called by the gui.py when dencam is running. This meant that if any other user was running the software, it would crash. Now the user must input their file path to the dencam codebase into the config file, and mppt.py must be able to parse this info itself. This also meant that the readme had to reflect the new sunsaver_log.py calling command to include the config file as well. Dencam cannot simply pass these arguments to mppt.py because sunsaver_log.py doesn't go through dencam, so sunsaver_log.py does need to include this config file. 