### PR TITLE
130 timestamp on recording

### DIFF
--- a/dencam/recorder_picamera2.py
+++ b/dencam/recorder_picamera2.py
@@ -3,7 +3,10 @@
 """
 import logging
 from picamera2.encoders import H264Encoder
-from picamera2 import Picamera2, Preview
+from picamera2 import Picamera2, Preview, MappedArray
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+import time
 
 from dencam.recorder import Recorder
 
@@ -70,5 +73,40 @@ class Picamera2Recorder(Recorder):
         log.info('Set up camera per configurations')
         self.camera = Picam2(configs)
         self.configs = configs
-
         super().finish_setup()
+
+    def update_timestamp(self):
+        self.camera.camera.pre_callback = self._pre_callback_wrapper
+
+    def _pre_callback_wrapper(self, request):
+        """ Wrapper function to call update_timestamp without needing to pass request
+        """
+        self.timestamp(request)
+
+    def timestamp(self, request):
+        font_size = 35
+        text_color = (255, 255, 255)
+        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", font_size)
+        bg_color = (0, 0, 0)
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+
+        with MappedArray(request, "main") as m:
+            image = Image.fromarray(m.array)
+            draw = ImageDraw.Draw(image)
+
+            bbox = draw.textbbox((0, 0), timestamp, font=font)
+            text_width = bbox[2] - bbox[0]
+            text_height = bbox[3] - bbox[1]
+
+            img_width, img_height = image.size
+            text_x = (img_width - text_width) // 2
+            text_y = 10
+
+            draw.rectangle(
+                [text_x, text_y, text_x + text_width, text_y + text_height],
+                fill=bg_color
+            )
+
+            draw.text((text_x, text_y), timestamp, fill=text_color, font=font)
+
+            m.array[:] = np.array(image)

--- a/dencam/recorder_picamera2.py
+++ b/dencam/recorder_picamera2.py
@@ -22,11 +22,10 @@ class Picam2:
         self.encoder = H264Encoder()
 
         self.camera = Picamera2()
-        self.camera.preview_configuration.enable_lores()
-        self.camera.preview_configuration.lores.size = (320, 240)
         self.camera.configure("preview")
         self.camera.start_preview(Preview.NULL)
         self.camera.start()
+        metadata = self.camera.capture_metadata()
 
     def start_preview(self):
         """Stop null preview, start QT preview and log
@@ -34,10 +33,10 @@ class Picam2:
         """
         self.camera.stop_preview()
         self.camera.start_preview(Preview.QT,
-                                  x=-4,
-                                  y=-25,
-                                  width=324,
-                                  height=245)
+                                  x=0,
+                                  y=-30,
+                                  width=320,
+                                  height=240)
         log.info('Started Preview')
 
     def stop_preview(self):
@@ -52,6 +51,7 @@ class Picam2:
         """Start recording and log
 
         """
+        # pylint: disable=unused-argument
         self.camera.start_recording(self.encoder, filename)
         log_message = 'Started Recording: ' + str(filename)
         log.info(log_message)
@@ -110,3 +110,31 @@ class Picamera2Recorder(Recorder):
             draw.text((text_x, text_y), timestamp, fill=text_color, font=font)
 
             m.array[:] = np.array(image)
+
+    def toggle_zoom(self):
+        """Toggle zoom
+
+        """
+        num_crop_steps = 25
+
+        size = self.camera.camera.capture_metadata()['ScalerCrop'][2:]
+        full_res = self.camera.camera.camera_properties['PixelArraySize']
+
+        for _ in range(num_crop_steps):
+            self.camera.camera.capture_metadata()
+
+            if not self.zoom_on:
+                size = [int(s * 0.95) for s in size]
+            else:
+                size = [int(s * 1.05) for s in size]
+                size = [min(s, r) for s, r in zip(size, full_res)]
+
+            offset = [(r - s) // 2 for r, s in zip(full_res, size)]
+            self.camera.camera.set_controls({"ScalerCrop": offset + size})
+
+        # make sure is fully zoomed out
+        if self.zoom_on:
+            bot_right = list(full_res)
+            self.camera.camera.set_controls({"ScalerCrop": [0, 0] + bot_right})
+
+        self.zoom_on = not self.zoom_on

--- a/lesehest.py
+++ b/lesehest.py
@@ -59,7 +59,7 @@ def main():
             try:
                 recorder = Picamera2Recorder(configs)
                 checking_camera = False
-            except RuntimeError as cam_error:
+            except IndexError as cam_error:
                 log.warning(cam_error)
                 if error_screen is None:
                     error_screen = ErrorScreen()


### PR DESCRIPTION
Very confused as to why the readme is also updated in this, as this is the current dev and readme and my commits on this branch don't touch the readme. Anyways- this adds the current timestamp to both the recording and preview page. The timestamp persists even upon zooming in and out. It's white text with a black background, the same as the original picamera implementation.