### PR TITLE
Anchor version number display so not cropped

### DIFF
--- a/dencam/gui.py
+++ b/dencam/gui.py
@@ -428,7 +428,8 @@ class NetworkPage(tk.Frame):
                                       fg='yellow',
                                       bg='black')
         self.version_label.place(height=version_placement[0],
-                                 x=version_placement[1],
+                                 relx=1.0,
+                                 anchor="ne",
                                  y=version_placement[2])
 
         next_page_placement = placements.values['network_next_page']


### PR DESCRIPTION
Changed how the version number is positioned so will always display full version number no matter how long. This was caught because the .dev0 appendix for the development branch was being cropped off.